### PR TITLE
Add curriculum and planning pages for training program

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,131 @@
+:root {
+  font-family: "Noto Sans KR", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color-scheme: light;
+  --primary: #0f4c81;
+  --secondary: #1261a0;
+  --accent: #f7931e;
+  --background: #f5f7fa;
+  --text: #1f2933;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--background);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+header {
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
+  color: #fff;
+  padding: 2rem 1.5rem;
+  text-align: center;
+  position: sticky;
+  top: 0;
+}
+
+header h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+  margin: 0 0.5rem;
+  font-weight: 600;
+  transition: opacity 0.2s ease;
+}
+
+nav a:hover,
+nav a:focus {
+  opacity: 0.75;
+}
+
+main {
+  margin: 2rem auto;
+  max-width: 900px;
+  padding: 0 1.5rem 3rem;
+}
+
+section {
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 15px 35px rgba(15, 76, 129, 0.15);
+  padding: 2rem;
+  margin-bottom: 2rem;
+}
+
+section h2 {
+  color: var(--primary);
+  font-size: 1.75rem;
+  margin-bottom: 1rem;
+}
+
+section h3 {
+  color: var(--secondary);
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+p,
+li {
+  font-size: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+ul {
+  padding-left: 1.25rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+}
+
+thead {
+  background: var(--secondary);
+  color: #fff;
+}
+
+td,
+th {
+  border: 1px solid rgba(15, 76, 129, 0.2);
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.badge {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 1.5rem;
+  color: rgba(31, 41, 51, 0.7);
+}
+
+@media (max-width: 640px) {
+  header h1 {
+    font-size: 1.5rem;
+  }
+
+  nav a {
+    display: inline-block;
+    margin: 0.25rem 0.35rem;
+  }
+}

--- a/curriculum.html
+++ b/curriculum.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>1개월 교육 커리큘럼 | 개선리더 30기</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <header>
+    <h1>1개월 집중 교육 커리큘럼</h1>
+    <nav>
+      <a href="index.html">홈</a>
+      <a href="curriculum.html">커리큘럼</a>
+      <a href="roadmap.html">로드맵</a>
+      <a href="resources.html">자료실</a>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <span class="badge">비개발자 맞춤 과정</span>
+      <h2>교육 구성 원칙</h2>
+      <ul>
+        <li>기초 개념 &rarr; 실습 &rarr; 현장 적용의 3단계 구성</li>
+        <li>실제 작업일지 데이터를 활용한 팀 프로젝트 중심 학습</li>
+        <li>n8n을 통한 노코드 자동화, RAG를 통한 지식 검색 경험 제공</li>
+        <li>주차별 역량 점검 및 피드백으로 학습 유지</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>주차별 커리큘럼</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>주차</th>
+            <th>학습 목표</th>
+            <th>핵심 활동</th>
+            <th>성과물</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>1주차<br><small>기초 다지기</small></td>
+            <td>
+              <ul>
+                <li>디지털 전환 이해</li>
+                <li>데이터 정리 기본 역량 확보</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>프로젝트 킥오프 &amp; 요구사항 워크숍</li>
+                <li>구글 스프레드시트/에어테이블로 데이터 구조 설계</li>
+                <li>작업일지 표준 입력 양식 만들기</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>표준화된 작업일지 양식 v1</li>
+                <li>데이터 품질 체크리스트</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>2주차<br><small>RAG 기초</small></td>
+            <td>
+              <ul>
+                <li>LLM &amp; RAG 개념 이해</li>
+                <li>문서 전처리 &amp; 임베딩 경험</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>작업일지 텍스트 클리닝 및 분류 실습</li>
+                <li>벡터DB(예: Pinecone/Weaviate) 개념 소개 및 데모</li>
+                <li>노코드 RAG 툴 활용해 Q&amp;A 봇 프로토타입 만들기</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>작업일지 기반 RAG Q&amp;A 시나리오 초안</li>
+                <li>FAQ 데이터셋 및 임베딩 파일</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>3주차<br><small>n8n 자동화</small></td>
+            <td>
+              <ul>
+                <li>n8n 환경 이해 및 워크플로 설계</li>
+                <li>데이터 파이프라인 자동화</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>n8n 기초 노드(Trigger, Function, HTTP, Spreadsheet) 실습</li>
+                <li>RAG 결과와 대시보드 데이터 연동</li>
+                <li>알림/보고 자동화 플로우 구축</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>n8n 기반 데이터 수집 &amp; 알림 워크플로</li>
+                <li>자동화 운영 가이드 초안</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>4주차<br><small>대시보드 &amp; 프로젝트 완성</small></td>
+            <td>
+              <ul>
+                <li>시각화 도구 실습</li>
+                <li>프로젝트 통합 및 발표</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>로코드 BI 도구(예: Google Looker Studio, Metabase) 실습</li>
+                <li>성과 지표 정의 및 대시보드 제작</li>
+                <li>최종 통합 리허설 &amp; 피드백</li>
+              </ul>
+            </td>
+            <td>
+              <ul>
+                <li>최종 통합 대시보드</li>
+                <li>RAG + n8n 연동 데모</li>
+                <li>운영 매뉴얼 &amp; 유지보수 계획</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>주간 세부 일정 (총 12회 오프라인 세션)</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>회차</th>
+            <th>주제</th>
+            <th>주요 내용</th>
+            <th>과제</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>1회차</td>
+            <td>프로젝트 오리엔테이션</td>
+            <td>목표 공유, 데이터 수집 현황 분석, 페르소나 정의</td>
+            <td>팀별 역할 분담 &amp; 개선 아이디어 도출</td>
+          </tr>
+          <tr>
+            <td>2회차</td>
+            <td>데이터 구조화 워크숍</td>
+            <td>데이터 항목 표준화, 오류 유형 파악</td>
+            <td>작업일지 양식 작성 및 데이터 정비</td>
+          </tr>
+          <tr>
+            <td>3회차</td>
+            <td>데이터 품질 진단</td>
+            <td>검증 규칙 수립, n8n 없이 검증 체크리스트 작성</td>
+            <td>품질 진단 리포트 제출</td>
+          </tr>
+          <tr>
+            <td>4회차</td>
+            <td>LLM &amp; RAG 이해</td>
+            <td>프롬프트 기초, 임베딩 개념, RAG 아키텍처 소개</td>
+            <td>작업일지 FAQ 초안 작성</td>
+          </tr>
+          <tr>
+            <td>5회차</td>
+            <td>문서 전처리 실습</td>
+            <td>텍스트 정제, 태깅, 메타데이터 부여</td>
+            <td>정제된 문서 세트 업로드</td>
+          </tr>
+          <tr>
+            <td>6회차</td>
+            <td>RAG 프로토타이핑</td>
+            <td>벡터DB 데모, 노코드 RAG 툴 구성</td>
+            <td>RAG Q&amp;A 시나리오 테스트</td>
+          </tr>
+          <tr>
+            <td>7회차</td>
+            <td>n8n 기초</td>
+            <td>인터페이스 소개, 워크플로 만들기 체험</td>
+            <td>개별 워크플로 과제 설계</td>
+          </tr>
+          <tr>
+            <td>8회차</td>
+            <td>데이터 파이프라인</td>
+            <td>API 연동, 스프레드시트 자동 업데이트</td>
+            <td>데이터 수집 플로 완성</td>
+          </tr>
+          <tr>
+            <td>9회차</td>
+            <td>알림 &amp; 보고 자동화</td>
+            <td>슬랙/이메일 알림, 주간 보고 자동 생성</td>
+            <td>알림 플로 테스트 로그 제출</td>
+          </tr>
+          <tr>
+            <td>10회차</td>
+            <td>대시보드 기초</td>
+            <td>시각화 원칙, 주요 KPI 설계</td>
+            <td>KPI 정의서 초안 작성</td>
+          </tr>
+          <tr>
+            <td>11회차</td>
+            <td>대시보드 제작</td>
+            <td>Looker Studio/Metabase 실습, 필터/차트 구성</td>
+            <td>대시보드 초안 제출</td>
+          </tr>
+          <tr>
+            <td>12회차</td>
+            <td>최종 통합 &amp; 발표</td>
+            <td>RAG + n8n + 대시보드 연결, 운영 계획 정리</td>
+            <td>최종 발표 &amp; 피드백 반영 계획</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>지원 프로그램</h2>
+      <ul>
+        <li>주차별 온라인 Q&amp;A 문답지 운영 (슬랙/노션 활용)</li>
+        <li>멘토 1:1 코칭 2회 제공 (2주차, 4주차)</li>
+        <li>평가 루브릭 제공 및 프로젝트 품질 진단</li>
+        <li>교육 종료 후 4주간 운영 지원 헬프데스크 운영</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    &copy; 2024 개선리더 30기 프로젝트. 모든 권리 보유.
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,22 +1,56 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <title>Home | My GitHub Page</title>
+  <title>개선리더 30기 | 디지털 전환 프로젝트</title>
   <link rel="stylesheet" href="assets/style.css">
 </head>
 <body>
   <header>
-    <h1>Welcome to My GitHub Page</h1>
+    <h1>개선리더 30기 디지털 전환 프로젝트</h1>
     <nav>
-      <a href="index.html">Home</a> |
-      <a href="about.html">About</a> |
-      <a href="blog.html">Blog</a> |
-      <a href="contact.html">Contact</a>
+      <a href="index.html">홈</a>
+      <a href="curriculum.html">커리큘럼</a>
+      <a href="roadmap.html">로드맵</a>
+      <a href="resources.html">자료실</a>
     </nav>
   </header>
   <main>
-    <p>This is the homepage of my GitHub Pages site.</p>
+    <section>
+      <span class="badge">인천발전소 기계반</span>
+      <h2>수기 작업일지를 데이터 자산으로</h2>
+      <p>
+        개선리더 30기 과제는 인천발전소 기계반에서 작성해 온 수기 작업일지를 전산화하고,
+        검색과 시각화를 통해 현장 의사결정을 돕는 데이터 대시보드를 구축하는 것입니다.
+      </p>
+      <p>
+        모든 구성원은 코딩 경험이 없기 때문에, 1개월간의 집중 교육을 통해 <strong>데이터 정리</strong>,
+        <strong>RAG(검색 증강 생성)</strong>, <strong>n8n 자동화</strong>, <strong>대시보드 설계</strong> 역량을 단계적으로 확보합니다.
+      </p>
+    </section>
+
+    <section>
+      <h2>교육 목표</h2>
+      <ul>
+        <li>현장 작업일지를 디지털화하기 위한 워크플로 설계 능력 확보</li>
+        <li>RAG 기반 지식 검색 및 답변 시스템 초급 구현</li>
+        <li>n8n을 활용한 무코드 자동화 시나리오 제작</li>
+        <li>데이터 대시보드 설계 및 의사결정 지원 인사이트 도출</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>진행 방식</h2>
+      <ul>
+        <li>주 3회(총 12회) 오프라인 집합 교육 + 실습</li>
+        <li>매주 1회 온라인 질의응답 및 피드백 세션</li>
+        <li>실제 작업일지를 활용한 팀 프로젝트 수행</li>
+        <li>전문 멘토의 단계별 리뷰 및 개선 제안</li>
+      </ul>
+    </section>
   </main>
+  <footer>
+    &copy; 2024 개선리더 30기 프로젝트. 모든 권리 보유.
+  </footer>
 </body>
 </html>

--- a/resources.html
+++ b/resources.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>자료실 | 개선리더 30기</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <header>
+    <h1>학습 &amp; 프로젝트 자료실</h1>
+    <nav>
+      <a href="index.html">홈</a>
+      <a href="curriculum.html">커리큘럼</a>
+      <a href="roadmap.html">로드맵</a>
+      <a href="resources.html">자료실</a>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <span class="badge">학습 지원</span>
+      <h2>필수 참고 자료</h2>
+      <ul>
+        <li><strong>데이터 정리</strong>: 구글 스프레드시트 기본 강의, 에어테이블 템플릿 모음</li>
+        <li><strong>RAG 이해</strong>: 검색 증강 생성 개요 PDF, Pinecone 튜토리얼 영상</li>
+        <li><strong>n8n 자동화</strong>: n8n 기본 노드 가이드, 커뮤니티 워크플로 샘플</li>
+        <li><strong>대시보드 설계</strong>: Looker Studio 시작하기, KPI 설계 체크리스트</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>워크숍 템플릿</h2>
+      <ul>
+        <li>요구사항 인터뷰 시트</li>
+        <li>데이터 품질 진단 시트</li>
+        <li>RAG 시나리오 설계 캔버스</li>
+        <li>n8n 워크플로 설계 캔버스</li>
+        <li>대시보드 KPI 맵</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>지원 채널</h2>
+      <ul>
+        <li>슬랙: #incheon-dx-support</li>
+        <li>주간 Q&amp;A 라이브: 매주 수요일 19시</li>
+        <li>헬프데스크 이메일: dx-support@incheonpower.co.kr</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    &copy; 2024 개선리더 30기 프로젝트. 모든 권리 보유.
+  </footer>
+</body>
+</html>

--- a/roadmap.html
+++ b/roadmap.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <title>실행 로드맵 | 개선리더 30기</title>
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <header>
+    <h1>프로젝트 실행 로드맵</h1>
+    <nav>
+      <a href="index.html">홈</a>
+      <a href="curriculum.html">커리큘럼</a>
+      <a href="roadmap.html">로드맵</a>
+      <a href="resources.html">자료실</a>
+    </nav>
+  </header>
+  <main>
+    <section>
+      <span class="badge">6개월 운영 계획</span>
+      <h2>로드맵 개요</h2>
+      <p>
+        교육을 마친 후 실제 현장 적용까지 고려한 6개월 로드맵입니다.
+        교육 기간 동안 구축한 데이터 파이프라인과 RAG, 대시보드를 안정적으로 운영하고
+        추가 개선을 이어갈 수 있도록 설계했습니다.
+      </p>
+    </section>
+
+    <section>
+      <h2>단계별 계획</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>단계</th>
+            <th>기간</th>
+            <th>핵심 목표</th>
+            <th>주요 활동</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>준비 단계</td>
+            <td>1개월</td>
+            <td>교육 커리큘럼 실행 및 파일럿 구축</td>
+            <td>
+              <ul>
+                <li>작업일지 데이터 정비 및 표준화</li>
+                <li>RAG Q&amp;A 프로토타입 테스트</li>
+                <li>n8n 자동화 파이프라인 설계</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>확장 단계</td>
+            <td>2~3개월</td>
+            <td>시스템 고도화 및 사용자 교육</td>
+            <td>
+              <ul>
+                <li>대시보드 지표 확장 및 정기 업데이트</li>
+                <li>현장 사용자 피드백 수집 및 개선</li>
+                <li>주요 프로세스 자동화 추가 구현</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>정착 단계</td>
+            <td>4~6개월</td>
+            <td>운영 체계 확립 및 유지보수 자동화</td>
+            <td>
+              <ul>
+                <li>지속적인 데이터 품질 모니터링</li>
+                <li>RAG 답변 정확도 개선 및 케이스 데이터 축적</li>
+                <li>운영 가이드라인 및 교육 자료 내재화</li>
+              </ul>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>역할 및 책임</h2>
+      <ul>
+        <li><strong>현장 담당자</strong>: 데이터 입력 및 품질 검증, 주간 리포트 확인</li>
+        <li><strong>프로젝트 리더</strong>: RAG 및 자동화 워크플로 점검, 개선 사항 의사결정</li>
+        <li><strong>멘토/외부 컨설턴트</strong>: 기술 지원, 월간 성과 리뷰, 역량 보완 교육</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>성공 지표</h2>
+      <ul>
+        <li>작업일지 디지털 입력률 90% 이상</li>
+        <li>RAG 기반 질의 응답 정확도 80% 이상</li>
+        <li>자동화 워크플로로 절감된 수기 작업 시간 월 30시간 이상</li>
+        <li>대시보드 활용 회의 주 1회 이상 정착</li>
+      </ul>
+    </section>
+  </main>
+  <footer>
+    &copy; 2024 개선리더 30기 프로젝트. 모든 권리 보유.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refresh the landing page with project goals for digitizing Incheon plant logbooks
- add a curriculum page detailing the four-week training schedule and session-by-session plan
- provide roadmap and resources pages plus shared styling for the static site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da90f3a6cc832f92320e63849ade5d